### PR TITLE
3A-G02-W011-PR01. Show Toast Message After User Action

### DIFF
--- a/components/ui/AddApplianceTile.tsx
+++ b/components/ui/AddApplianceTile.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Plus, CheckCircle2 } from "lucide-react";
+import { useState } from "react";
+import { Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import AddApplianceModal from "@/components/ui/AddApplianceModal";
+import SuccessToast from "@/components/ui/SuccessToast";
 
 export default function AddApplianceTile() {
   const router = useRouter();
@@ -15,13 +16,6 @@ export default function AddApplianceTile() {
     setSuccessMessage(`"${deviceName}" added to your fleet!`);
     router.refresh();
   }
-
-  // Auto-dismiss toast after 3.5 s
-  useEffect(() => {
-    if (!successMessage) return;
-    const timer = setTimeout(() => setSuccessMessage(null), 3500);
-    return () => clearTimeout(timer);
-  }, [successMessage]);
 
   return (
     <>
@@ -46,13 +40,10 @@ export default function AddApplianceTile() {
         />
       )}
 
-      {/* Success toast — sits above the bottom nav (bottom-24 = 96px) */}
-      {successMessage && (
-        <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2.5 rounded-xl bg-bida/15 border border-bida/30 backdrop-blur-sm px-4 py-3 shadow-lg w-[calc(100%-2rem)] max-w-97.5">
-          <CheckCircle2 className="w-4 h-4 text-bida shrink-0" />
-          <p className="text-sm font-semibold text-bida">{successMessage}</p>
-        </div>
-      )}
+      <SuccessToast
+        message={successMessage}
+        onDismiss={() => setSuccessMessage(null)}
+      />
     </>
   );
 }

--- a/components/ui/HomeBudgetEditor.tsx
+++ b/components/ui/HomeBudgetEditor.tsx
@@ -4,6 +4,7 @@ import { PencilLine, X } from "lucide-react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import SuccessToast from "@/components/ui/SuccessToast";
 
 type HomeBudgetEditorProps = {
   initialBudget: number;
@@ -22,6 +23,7 @@ export default function HomeBudgetEditor({ initialBudget }: HomeBudgetEditorProp
   const [isOpen, setIsOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   function openEditor() {
     setInputValue(initialBudget.toFixed(2));
@@ -86,10 +88,12 @@ export default function HomeBudgetEditor({ initialBudget }: HomeBudgetEditorProp
     setInputValue(nextBudget.toFixed(2));
     setIsOpen(false);
     setIsSaving(false);
+    setSuccessMessage("Home budget updated.");
     router.refresh();
   }
 
   return (
+    <>
     <div className="mb-3">
       <div className="flex items-center justify-between">
         <span className="text-sm text-white/70">Home Budget</span>
@@ -169,5 +173,10 @@ export default function HomeBudgetEditor({ initialBudget }: HomeBudgetEditorProp
         </div>
       ) : null}
     </div>
+    <SuccessToast
+      message={successMessage}
+      onDismiss={() => setSuccessMessage(null)}
+    />
+    </>
   );
 }

--- a/components/ui/RelayToggle.tsx
+++ b/components/ui/RelayToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Power } from "lucide-react";
+import SuccessToast from "@/components/ui/SuccessToast";
 
 interface RelayToggleProps {
   deviceId: string;
@@ -16,6 +17,7 @@ export default function RelayToggle({
 }: RelayToggleProps) {
   const [relayState, setRelayState] = useState(initialRelayState);
   const [isPending, setIsPending] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   async function handleToggle(e: React.MouseEvent) {
     // Prevent parent Link navigation when clicking the toggle
@@ -27,6 +29,7 @@ export default function RelayToggle({
     // Optimistic update
     setRelayState(newState);
     setIsPending(true);
+    setSuccessMessage(null);
 
     try {
       const res = await fetch(`/api/devices/${deviceId}/relay`, {
@@ -38,6 +41,8 @@ export default function RelayToggle({
       if (!res.ok) {
         // Revert on error
         setRelayState(!newState);
+      } else {
+        setSuccessMessage(`Device turned ${newState ? "on" : "off"}.`);
       }
     } catch {
       // Revert on network error
@@ -49,6 +54,7 @@ export default function RelayToggle({
 
   if (variant === "compact") {
     return (
+      <>
       <button
         type="button"
         onClick={handleToggle}
@@ -62,11 +68,17 @@ export default function RelayToggle({
       >
         <Power className="w-3.5 h-3.5" />
       </button>
+      <SuccessToast
+        message={successMessage}
+        onDismiss={() => setSuccessMessage(null)}
+      />
+      </>
     );
   }
 
   // Full variant for Device Detail
   return (
+    <>
     <div className="rounded-xl bg-white/[0.03] backdrop-blur border border-white/[0.06] p-5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -111,5 +123,10 @@ export default function RelayToggle({
         Pag naka-off, titigil ang data collection at power sa appliance.
       </p>
     </div>
+    <SuccessToast
+      message={successMessage}
+      onDismiss={() => setSuccessMessage(null)}
+    />
+    </>
   );
 }

--- a/components/ui/SuccessToast.tsx
+++ b/components/ui/SuccessToast.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { CheckCircle2 } from "lucide-react";
+
+type SuccessToastPosition = "bottom-center" | "top-right";
+
+type SuccessToastProps = {
+  message: string | null;
+  durationMs?: number;
+  position?: SuccessToastPosition;
+  onDismiss: () => void;
+};
+
+const positionClasses: Record<SuccessToastPosition, string> = {
+  "bottom-center":
+    "bottom-24 left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] max-w-97.5",
+  "top-right": "top-6 right-6 w-[calc(100%-2rem)] max-w-sm",
+};
+
+export default function SuccessToast({
+  message,
+  durationMs = 3500,
+  position = "bottom-center",
+  onDismiss,
+}: SuccessToastProps) {
+  useEffect(() => {
+    if (!message) return;
+
+    const timer = setTimeout(onDismiss, durationMs);
+    return () => clearTimeout(timer);
+  }, [durationMs, message, onDismiss]);
+
+  if (!message || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed z-50 flex items-center gap-2.5 rounded-xl bg-bida/15 border border-bida/30 backdrop-blur-sm px-4 py-3 shadow-lg ${positionClasses[position]}`}
+    >
+      <CheckCircle2 className="w-4 h-4 text-bida shrink-0" />
+      <p className="text-sm font-semibold text-bida">{message}</p>
+    </div>,
+    document.body
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,8 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".open-next/**",
+    ".wrangler/**",
     "out/**",
     "build/**",
     "next-env.d.ts",


### PR DESCRIPTION
## Summary

Added success toast messages after completed user-side actions in the WattWise app.

This gives users clear feedback when an action succeeds, such as adding an appliance, updating the home budget, or toggling a device relay.

## Why is it needed?

Users should receive immediate confirmation after completing important actions.

Without success feedback, users may be unsure whether their action was saved or processed correctly. Toast messages improve clarity, reduce confusion, and make the app feel more responsive and polished.

## What changed

Created a reusable success toast component:
SuccessToast.tsx — Shared toast UI for success messages with auto-dismiss behavior.

Updated user-side actions to show toast feedback:
AddApplianceTile.tsx — Shows a toast after an appliance is successfully added.
HomeBudgetEditor.tsx — Shows a toast after the home budget is successfully updated.
RelayToggle.tsx — Shows a toast after a device relay is successfully turned on or off.

Refactored the existing add appliance success message to use the shared toast component instead of inline toast markup.

Added portal rendering for toast messages so they display consistently above the app UI.

Kept toast usage focused on user-side actions where feedback is visible and meaningful.

Updated ESLint ignores for generated deployment output directories.

## Checklist

- [x] Code follows project guidelines.
- [x] Success toast component added and reused.
- [x] Toast messages appear after successful user actions.
- [x] Toasts auto-dismiss after a short duration.
- [x] Local typechecks run and basic sanity verified.
- [x] No breaking changes to existing runtime behavior.
