### PR TITLE
3A-G02-W015-PR01. Dynamic Page Titles

### DIFF
--- a/app/admin/ai-costs/page.tsx
+++ b/app/admin/ai-costs/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { Brain } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'AI Cost Tracker',
+};
 
 export default function AdminAiCostsPage() {
   return (

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { Globe } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Global Analytics',
+};
 
 export default function AdminAnalyticsPage() {
   return (

--- a/app/admin/growth/page.tsx
+++ b/app/admin/growth/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { TrendingUp } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Revenue & Growth',
+};
 
 export default function AdminGrowthPage() {
   return (

--- a/app/admin/health/page.tsx
+++ b/app/admin/health/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { HeartPulse } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'System Health',
+};
 
 export default function AdminHealthPage() {
   return (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { Shield } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Admin Overview',
+};
 
 export default function AdminPage() {
   return (

--- a/app/admin/rates/page.tsx
+++ b/app/admin/rates/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { DollarSign } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Rate Editor',
+};
 
 export default function AdminRatesPage() {
   return (

--- a/app/dashboard/[deviceId]/page.tsx
+++ b/app/dashboard/[deviceId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import {
@@ -13,6 +14,23 @@ import {
 import RealtimeRefreshBridge from "@/components/realtime/RealtimeRefreshBridge";
 import RelayToggle from "@/components/ui/RelayToggle";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+
+export async function generateMetadata(props: {
+  params: Promise<{ deviceId: string }>;
+}): Promise<Metadata> {
+  const { deviceId } = await props.params;
+  const supabase = await createClient();
+
+  const { data: device } = await supabase
+    .from("devices")
+    .select("device_name")
+    .eq("id", deviceId)
+    .maybeSingle<{ device_name: string }>();
+
+  return {
+    title: device?.device_name ?? "Device Detail",
+  };
+}
 
 type DeviceRow = {
   id: string;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import {
   TrendingDown,
@@ -26,6 +27,10 @@ import {
 } from "@/lib/meralco-rates";
 
 const MOCK_AI_TIP = 'Overall usage is 10% lower today, Bida!';
+
+export const metadata: Metadata = {
+  title: 'Dashboard',
+};
 
 type DeviceRow = {
   id: string;

--- a/app/forgot-password/layout.tsx
+++ b/app/forgot-password/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Forgot Password",
+};
+
+export default function ForgotPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { TrendingDown, Wind, Refrigerator, Tv, HelpCircle, Power } from "lucide-react";
@@ -10,6 +11,10 @@ import ThemeToggle from "@/components/ui/ThemeToggle";
 import { createClient } from "@/lib/supabase/server";
 import { computeMeralcoBill, getActiveMeralcoRates } from "@/lib/meralco-rates";
 import CoachingFeed from "@/components/insights/CoachingFeed";
+
+export const metadata: Metadata = {
+  title: 'Insights',
+};
 
 type DeviceRow = {
   id: string;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,10 @@ import SupabaseProvider from "@/components/providers/SupabaseProvider";
 import MobileViewport from "@/components/ui/MobileViewport";
 
 export const metadata: Metadata = {
-  title: "Wattwise",
+  title: {
+    template: "%s | WattWise",
+    default: "WattWise",
+  },
   description: "Smart Energy. Real Savings.",
 };
 

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Login",
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/onboarding/layout.tsx
+++ b/app/onboarding/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Welcome",
+};
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/register/layout.tsx
+++ b/app/register/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Register",
+};
+
+export default function RegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/reset-password/layout.tsx
+++ b/app/reset-password/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Reset Password",
+};
+
+export default function ResetPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
Summary
This change implements dynamic and static page titles across all routes. Every browser tab now displays a descriptive title (e.g., Insights | WattWise) instead of the generic default.

Why is it needed?
UX Navigability: Users with multiple tabs open can now easily distinguish between different sections of the app (Dashboard vs. Insights vs. Admin).

SEO Optimization: Search engines use the <title> tag to index specific pages; providing unique titles ensures the platform is correctly crawled and ranked.

Professionalism: Standardizes the look and feel of the platform to match modern web standards.

What changed
Root Layout (app/layout.tsx): Configured a title template "%s | WattWise". This automatically appends the brand name to any title exported by a child page.

Static Pages: Added metadata exports to the following pages:

Dashboard, Insights, Admin Overview, Rate Editor, Revenue & Growth, AI Cost Tracker, System Health, and Global Analytics.

Dynamic Device Page (app/dashboard/[deviceId]/page.tsx): Implemented generateMetadata to fetch the actual device name (e.g., "Living Room Aircon") from Supabase and display it in the browser tab.

Client Component Support: Created co-located layout.tsx files for Login, Register, Onboarding, and Forgot Password pages to handle metadata, as these pages use "use client".

Checklist
[x] Code follows project guidelines.

[x] Tested locally and works as expected.

[x] No breaking changes to existing features.